### PR TITLE
docs: add note about creating Personal access tokens in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Allows you to create a label in all existing repositories in an organization.
 ### `triage/subscribe-to-org-repos.js` - Subscribe to Org Repos
 Allows you to subscribe to all repositories in an organization.
 
+Note: Create the token with the Personal access tokens (classic) methods
+
 ## Usage
 1. Clone the repository
 2. Install the required dependency for the script you want to use


### PR DESCRIPTION
It can only be done this way

https://docs.github.com/en/rest/activity/watching?apiVersion=2022-11-28#set-a-repository-subscription--fine-grained-access-tokens